### PR TITLE
Add "copy commit" button to header

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -264,6 +264,7 @@
                         <div>{{ run.date }}</div>
                         <a href="https://github.com/bevyengine/bevy/commit/{{ run.commit }}">{{
                             run.commit|truncate(length=7, end="") }}</a>
+                        <a title="Copy commit hash" class="icon-link copy-commit" href="#" data-value="{{ run.commit }}"><i class="fa-solid fa-copy fa-flip-both"></i></a>
                     </div>
                 </th>
                 {% endfor -%}
@@ -354,6 +355,25 @@
                 popovers[i].scrollTop = popovers[i].scrollHeight;
             }
         });
+
+        const copyCommitLinkList = document.getElementsByClassName('copy-commit');
+        for (let i = 0; i < copyCommitLinkList.length; i++) {
+            copyCommitLinkList[i].addEventListener('click', event => {
+                event.preventDefault();
+
+                const commit = event.currentTarget.getAttribute('data-value');
+                navigator.clipboard.writeText(commit);
+
+                const icon = event.currentTarget.querySelector("i");
+                icon.classList.remove("fa-copy");
+                icon.classList.add("fa-check");
+
+                setTimeout(() => {
+                    icon.classList.remove("fa-check");
+                    icon.classList.add("fa-copy");
+                }, 2000);
+            });
+        }
     </script>
 </body>
 


### PR DESCRIPTION
## Objective

I am often copying and pasting the commit hashes in the header so that I can properly git bisect changes between runs.

With the commit hashes being vertical and links themselves, this is a bit finicky.

## Solution

Add a "copy" button.

https://github.com/user-attachments/assets/e9ab6a29-bc12-4623-9790-1a2a56657f79

Note: The cursor not showing up like "cursor: pointer" is a quirk of the screen recording.