### PR TITLE
Fix platform icons and `hr` tags bleeding through sticky header

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -28,6 +28,8 @@
             position: sticky;
             top: 0;
             background-color: var(--bs-dark-bg-subtle);
+            /* Prevent bleed-through of hr tags and ::before content in table */
+            z-index: 1
         }
 
         table {


### PR DESCRIPTION
## Solution

This seems to be caused by quirks in browsers involving the stacking context of `<hr>` tags specifically, and also content created with `::before` pseudo-selectors.

Adding a small `z-index` to `th` seems to fix the issue in Chrome and Firefox, without blocking popovers.

## Before

https://github.com/user-attachments/assets/fe6d29b7-ce23-46f5-a8b3-314c24768585

## After

https://github.com/user-attachments/assets/7bb5653c-1265-4036-bc66-e0ea1c62ac54
