### PR TITLE
Fix disappearing popover

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -1,5 +1,5 @@
 {% import "macros.html" as macros %}
-
+<!DOCTYPE html>
 <html>
 
 <head>
@@ -342,7 +342,7 @@
         crossorigin="anonymous"></script>
     <script>
         const popoverTriggerList = document.querySelectorAll(' [data-bs-toggle="popover" ]')
-        const popoverList = [...popoverTriggerList].map(popoverTriggerEl => new bootstrap.Popover(popoverTriggerEl))
+        const popoverList = [...popoverTriggerList].map(popoverTriggerEl => new bootstrap.Popover(popoverTriggerEl, { container: 'body' }))
 
         function toggle_visibility() {
             const examples = document.getElementsByClassName("all-good");

--- a/templates/index.html
+++ b/templates/index.html
@@ -342,7 +342,10 @@
         crossorigin="anonymous"></script>
     <script>
         const popoverTriggerList = document.querySelectorAll(' [data-bs-toggle="popover" ]')
-        const popoverList = [...popoverTriggerList].map(popoverTriggerEl => new bootstrap.Popover(popoverTriggerEl, { container: 'body' }))
+        const popoverList = [...popoverTriggerList].map(
+            (popoverTriggerEl) =>
+                new bootstrap.Popover(popoverTriggerEl, { container: "body" })
+        );
 
         function toggle_visibility() {
             const examples = document.getElementsByClassName("all-good");


### PR DESCRIPTION
## Objective

Fixes #12

## Solution

Following a lead from https://popper.js.org/docs/v2/faq/#why-is-my-popper-in-the-wrong-location-or-not-visible-at-all I added a doctype to the document.

That helped, but it seemed like popper was still failing to position things correctly.

The issue seemingly went away after after removing the fixed table header, and it seems like the fix for positioning with a fixed table header is to make sure that the popover is created on `body`.

Together, this seems to fix the problem completely.