### PR TITLE
Fix popovers appearing off-screen for rows near bottom of page

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -361,6 +361,20 @@
             }
         });
 
+        // Popovers are initially positioned before the image loads and need to be adjusted
+        // once the image is partially loaded and resizes the container.
+        let popoverResizeObserver = null;
+        document.addEventListener("inserted.bs.popover", (event) => {
+            const popover = document.querySelector(".popover");
+
+            popoverResizeObserver?.disconnect();
+            popoverResizeObserver = new ResizeObserver(() => {
+                const instance = bootstrap.Popover.getInstance(event.target);
+                instance.update();
+            });
+            popoverResizeObserver.observe(popover);
+        });
+
         const copyCommitLinkList = document.getElementsByClassName('copy-commit');
         for (let i = 0; i < copyCommitLinkList.length; i++) {
             copyCommitLinkList[i].addEventListener('click', event => {

--- a/templates/index.html
+++ b/templates/index.html
@@ -362,7 +362,7 @@
         });
 
         // Popovers are initially positioned before the image loads and need to be adjusted
-        // once the image is partially loaded and resizes the container.
+        // once the image is partially loaded and the container is resized.
         let popoverResizeObserver = null;
         document.addEventListener("inserted.bs.popover", (event) => {
             const popover = document.querySelector(".popover");


### PR DESCRIPTION
## Objective

Fixes #11 

## Solution

I tried a [solution](https://github.com/TheBevyFlock/bevy-example-runner/issues/11#issuecomment-2676354469) with `onload` for the `img` first, which worked. But `onload` fires after the image is *completely* loaded. The browser can read image metadata and resizes content well before `onload` happens.

Instead, I add a `ResizeObserver` to the popover when it's created, which is responsive immediately after the image's size is determined from metadata before it's completely loaded.