### PR TITLE
Minor style improvements for platform tooltips

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -199,10 +199,10 @@
         .platform-tooltip .tooltiptext {
             visibility: hidden;
             width: 120px;
-            background-color: #555;
+            background-color: var(--bs-secondary-bg);
             color: #fff;
             text-align: center;
-            padding: 5px 0;
+            padding: 5px 5px;
             border-radius: 6px;
 
             position: absolute;
@@ -223,7 +223,7 @@
             margin-left: -5px;
             border-width: 5px;
             border-style: solid;
-            border-color: #555 transparent transparent transparent;
+            border-color: var(--bs-secondary-bg) transparent transparent transparent;
         }
 
         .platform-tooltip:hover .tooltiptext {


### PR DESCRIPTION
## Objective

- Fix tooltip being exactly as wide as text content
- Use theme for tooltip background color

## Before / After

<img width="349" alt="Screenshot 2025-02-24 at 7 12 13 PM" src="https://github.com/user-attachments/assets/61896bf0-e217-4741-bddd-b97494c06e7c" />

<img width="349" alt="Screenshot 2025-02-24 at 7 57 01 PM" src="https://github.com/user-attachments/assets/19f0e364-aa16-4b2a-a0b2-559dc80b8837" />

