### PR TITLE
Fix icon spacing

### DIFF
--- a/src/template.rs
+++ b/src/template.rs
@@ -16,6 +16,11 @@ pub fn build_site(
 
     let mut tera = Tera::default();
     tera.add_raw_template(
+        "icons.html",
+        &std::fs::read_to_string("./templates/icons.html").unwrap(),
+    )
+    .unwrap();
+    tera.add_raw_template(
         "macros.html",
         &std::fs::read_to_string("./templates/macros.html").unwrap(),
     )

--- a/templates/icons.html
+++ b/templates/icons.html
@@ -1,0 +1,39 @@
+{# Status #}
+
+{% macro success(class="") %}
+<i class="fa-check fa-solid text-success-emphasis {{ class }}"></i>
+{% endmacro %}
+
+{% macro fail(class="") %}
+<i class="fa-triangle-exclamation fa-solid text-danger {{ class }}"></i>
+{% endmacro %}
+
+{% macro changed(class="") %}
+<i class="fa-star fa-solid text-warning-emphasis {{ class }}"></i>
+{% endmacro %}
+
+{% macro missing_screenshot(class="") %}
+<i class="fa-eye-slash text-info-emphasis fa-regular {{ class }}"></i>
+{% endmacro %}
+
+{# Platform #}
+
+{% macro windows(class="") %}
+<i class="fa-brands fa-windows {{ class }}"></i>
+{% endmacro %}
+
+{% macro macos(class="") %}
+<i class="fa-brands fa-apple {{ class }}"></i>
+{% endmacro %}
+
+{% macro ios(class="") %}
+<i class="fa-brands fa-apple {{ class }}"></i>
+{% endmacro %}
+
+{% macro linux(class="") %}
+<i class="fa-brands fa-linux {{ class }}"></i>
+{% endmacro %}
+
+{% macro android(class="") %}
+<i class="fa-brands fa-android {{ class }}"></i>
+{% endmacro %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,4 +1,5 @@
 {% import "macros.html" as macros %}
+{% import "icons.html" as icons %}
 <!DOCTYPE html>
 <html>
 
@@ -239,21 +240,20 @@
         <thead>
             <tr>
                 <th class="no-border" style="min-width: 35em;">
-                    <div style="padding: 3px;">
-                        <span class="success"></span> Example ran successfully, screenshot didn't change
+                    <div class="p-1">
+                        {{ icons::success(class="fa-fw") }} Example ran successfully, screenshot didn't change
                     </div>
-                    <div style="padding: 3px;">
-                        <span class="missing-screenshot"></span> Example ran successfully, but couldn't capture a
+                    <div class="p-1">
+                        {{ icons::missing_screenshot(class="fa-fw") }} Example ran successfully, but couldn't capture a
                         screenshot
                     </div>
-                    <div style="padding: 3px;">
-                        <span class="changed"></span> Example ran successfully, screenshot changed
+                    <div class="p-1">
+                        {{ icons::changed(class="fa-fw") }} Example ran successfully, screenshot changed
                     </div>
-                    <div style="padding: 3px;">
-                        <span class="fail"></span> Error running the example
+                    <div class="p-1">
+                        {{ icons::fail(class="fa-fw") }} Error running the example
                     </div>
-                    <br />
-                    <div class="form-check form-switch form-check-reverse">
+                    <div class="form-check form-switch form-check-reverse mt-3">
                         <input class="form-check-input" type="checkbox" id="flexSwitchCheckReverse" checked
                             onclick="toggle_visibility()">
                         <label class="form-check-label" for="flexSwitchCheckReverse">Only show flaky examples</label>
@@ -277,20 +277,23 @@
             {% if example.category == "Mobile" %}
             <tr {% if example.flaky -%}class="flaky" {% else -%}class="all-good" style="display: none;" {% endif -%}>
                 <td style="border-right: none;">{{ example.category }} / {{ example.name }}</td>
-                <td style="border-left: none;">
+                <td style="border-left: none;" class="text-center">
                     {% for mobile in all_mobile_platforms | sort %}
-                    {% if mobile is starting_with("Android") %}
-                    <span class="android platform-tooltip"><span class="tooltiptext">{{ mobile }}</span></span>
-                    {% elif mobile is starting_with("iOS") %}
-                    <span class="ios platform-tooltip"><span class="tooltiptext">{{ mobile }}</span></span>
-                    {% endif %}
-                    {% if not loop.last %}
-                    <hr />
-                    {% endif %}
+                    <span class="platform-tooltip">
+                        {% if mobile is starting_with("Android") %}
+                        {{ icons::android() }}
+                        {% elif mobile is starting_with("iOS") %}
+                        {{ icons::ios() }}
+                        {% endif %}
+                        <span class="tooltiptext">{{mobile}}</span>
+                        </span>
+                        {% if not loop.last %}
+                        <hr />
+                        {% endif %}
                     {% endfor %}
                 </td>
                 {% for run in runs -%}
-                <td style="text-align: center;">
+                <td class="text-center">
                     {% if run.results[example.name] -%}
                     {% for mobile in all_mobile_platforms | sort %}
                     {{ macros::status(example_name=example.name, platform=mobile, run=run) }}
@@ -315,13 +318,13 @@
             {% if example.category != "Mobile" %}
             <tr {% if example.flaky -%}class="flaky" {% else -%}class="all-good" style="display: none;" {% endif -%}>
                 <td style="border-right: none;">{{ example.category }} / {{ example.name }}</td>
-                <td style="border-left: none;">
-                    <span class="linux"></span>
+                <td style="border-left: none;" class="text-center">
+                    {{ icons::linux() }}
                     <hr>
-                    <span class="macos"></span>
+                    {{ icons::macos() }}
                 </td>
                 {% for run in runs -%}
-                <td style="text-align: center;">
+                <td class="text-center">
                     {% if run.results[example.name] -%}
                     {{ macros::status(example_name=example.name, platform="Linux", run=run) }}
                     <hr />

--- a/templates/macros.html
+++ b/templates/macros.html
@@ -1,3 +1,5 @@
+{% import "icons.html" as icons %}
+
 {% macro status(example_name, platform, run) %}
 {% if run.results[example_name][platform] -%}
 {% if run.results[example_name][platform] == "Successes" -%}
@@ -6,30 +8,30 @@
     data-bs-content='<img class="img-fluid" src="{{ run.screenshots[example_name][platform].0 }}" />'>
     <a href="{{ run.screenshots[example_name][platform].2 }}" target="_blank">
         {% if run.screenshots[example_name][platform].1 == "Similar" -%}
-        <span class="success"></span>
+        {{ icons::changed() }}
         {% else -%}
-        <span class="changed"></span>
+        {{ icons::success() }}
         {% endif -%}
     </a>
 </div>
 {% else -%}
-<span class="missing-screenshot" style="font-size: 1rem;"></span>
+{{ icons::missing_screenshot() }}
 {% endif -%}
 {% elif run.results[example_name][platform] == "Failures" -%}
 {% if run.logs[example_name] -%}
 {% if run.logs[example_name][platform] -%}
 <div data-bs-toggle="popover" data-bs-trigger="hover" data-bs-html=true data-bs-custom-class="log-popover"
     data-bs-content='<pre>{{ run.logs[example_name][platform] }}</pre>'>
-    <span class="fail" style="font-size: 1.5rem;"></span>
+    {{ icons::fail() }}
 </div>
 {% else -%}
-<span class="fail" style="font-size: 1.5rem;"></span>
+{{ icons::fail() }}
 {% endif -%}
 {% else -%}
-<span class="fail" style="font-size: 1.5rem;"></span>
+{{ icons::fail() }}
 {% endif -%}
 {% elif run.results[example_name][platform] == "NoScreenshots" -%}
-<span class="missing-screenshot" style="font-size: 1rem;"></span>
+{{ icons::missing_screenshot() }}
 {% endif -%}
 {% else -%}
 -


### PR DESCRIPTION
## Objective

Fix some minor alignment issues with some of the status / platform icons.

## Solution

- Add `fa-fw` (fixed width) to top-left icons
- Center content in platform column
- Swap fail icon for one that is the same size as the others
- Some minor tidying, using bootstrap classes in place of some inline styles

## Before

Note the three pink boxes indicating misalignment

<img width="647" alt="Screenshot 2025-02-24 at 8 17 24 PM" src="https://github.com/user-attachments/assets/7ca5f631-2e09-4d9a-b8f2-711ab39d2cdc" />

## After

<img width="647" alt="Screenshot 2025-02-24 at 8 17 18 PM" src="https://github.com/user-attachments/assets/a1df1b4d-6bd4-46b2-a7e4-cb7d27dc441d" />

## Discussion

I wasn't able to determine why the `fail` icon was the way that it was (larger font size, css border). Let me know if you're not feeling what I did there.